### PR TITLE
メイン食材のセレクトボックス追加と選択内容による出力結果の分岐を追加

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,17 +1,18 @@
 class FoodsController < ApplicationController
   before_action :set_food, only: %i[show]
   before_action :set_main_ingredients, only: %i[index]
-  before_action :select_food, only: %i[index]
 
   def index
-    if @random_food.present? 
-      # ランダム選択が成功した場合
-      redirect_to food_path(@random_food) 
-    elsif !@random_food.nil? && @random_food.blank?
-      # カテゴリーとメイン食材の組み合わせが一致せずにから配列が帰ってきた場合
-      # !@random_food.nil?：初期のparamsの値なしで反応させないため
-      flash[:danger] = "一致するものがありませんでした。もう一度お試しください。"
-      redirect_to root_url
+    # 選ぶボタン押下後
+    if food_params.present?
+      @random_food = random_food
+      # ちゃんと選択できたか？
+      if @random_food.present?
+        redirect_to food_path(@random_food)
+      else
+        flash[:danger] = '選択されたカテゴリーとメイン食材の組み合わせが存在しないため一致するものが見つかりませんでした。もう一度お試しください。'
+        redirect_to root_path
+      end
     end
   end
 
@@ -24,31 +25,8 @@ class FoodsController < ApplicationController
     @food = Food.find(params[:id])
   end
 
-  def select_food
-    @random_food = random_food  # indexのifの評価をしやすくするため
-  end
-
   def random_food
-    food = food_params
-    # paramsがあるかどうか
-    if food.present?
-      if food[:category].present? && food[:main_ingredients].present? && Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).present?
-        # カテゴリーとメイン食材がどちらも選択されて、かつそれらが正しい組み合わせである場合(例：肉と牛肉)
-        Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).order('RAND()').limit(1).first
-      elsif food[:category].present? && food[:main_ingredients].present? && Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).blank?
-        # カテゴリーとメイン食材がどちらも選択されて、かつそれらが存在しない組み合わせである場合(例：肉と鰤)
-        []  # nilだと何もない困るのでから配列
-      elsif food[:category].present? && food[:main_ingredients].blank?
-        # カテゴリーが選択されていて、メイン食材が選択されていない場合
-        Food.where(category: food[:category]).order('RAND()').limit(1).first
-      elsif food[:category].blank? && food[:main_ingredients].present?
-        # カテゴリーが選択されていない、メイン食材が選択されている場合
-        Food.where(main_ingredients: food[:main_ingredients]).order('RAND()').limit(1).first
-      else
-        # カテゴリーとメイン食材のどちらも選択されていない場合
-        Food.where( 'id >= ?', rand(Food.count) + 1 ).first
-      end
-    end
+    Food.random_select_by(category: food_params[:category], main_ingredients: food_params[:main_ingredients])
   end
 
   def food_params

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,8 +1,18 @@
 class FoodsController < ApplicationController
   before_action :set_food, only: %i[show]
+  before_action :set_main_ingredients, only: %i[index]
+  before_action :select_food, only: %i[index]
 
   def index
-    redirect_to food_path(random_food) if food_params[:category].present?
+    if @random_food.present? 
+      # ランダム選択が成功した場合
+      redirect_to food_path(@random_food) 
+    elsif !@random_food.nil? && @random_food.blank?
+      # カテゴリーとメイン食材の組み合わせが一致せずにから配列が帰ってきた場合
+      # !@random_food.nil?：初期のparamsの値なしで反応させないため
+      flash[:danger] = "一致するものがありませんでした。もう一度お試しください。"
+      redirect_to root_url
+    end
   end
 
   def show
@@ -14,11 +24,38 @@ class FoodsController < ApplicationController
     @food = Food.find(params[:id])
   end
 
+  def select_food
+    @random_food = random_food  # indexのifの評価をしやすくするため
+  end
+
   def random_food
-    Food.where(category: food_params[:category]).order('RAND()').limit(1).first
+    food = food_params
+    # paramsがあるかどうか
+    if food.present?
+      if food[:category].present? && food[:main_ingredients].present? && Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).present?
+        # カテゴリーとメイン食材がどちらも選択されて、かつそれらが正しい組み合わせである場合(例：肉と牛肉)
+        Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).order('RAND()').limit(1).first
+      elsif food[:category].present? && food[:main_ingredients].present? && Food.where(category: food[:category], main_ingredients: food[:main_ingredients]).blank?
+        # カテゴリーとメイン食材がどちらも選択されて、かつそれらが存在しない組み合わせである場合(例：肉と鰤)
+        []  # nilだと何もない困るのでから配列
+      elsif food[:category].present? && food[:main_ingredients].blank?
+        # カテゴリーが選択されていて、メイン食材が選択されていない場合
+        Food.where(category: food[:category]).order('RAND()').limit(1).first
+      elsif food[:category].blank? && food[:main_ingredients].present?
+        # カテゴリーが選択されていない、メイン食材が選択されている場合
+        Food.where(main_ingredients: food[:main_ingredients]).order('RAND()').limit(1).first
+      else
+        # カテゴリーとメイン食材のどちらも選択されていない場合
+        Food.where( 'id >= ?', rand(Food.count) + 1 ).first
+      end
+    end
   end
 
   def food_params
-    params.permit(:category)
+    params.permit(:category, :main_ingredients)
+  end
+
+  def set_main_ingredients
+    @main_ingredients = Food.pluck(:main_ingredients).uniq
   end
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -9,4 +9,17 @@ class Food < ApplicationRecord
   has_many :histories
   has_many :user, through: :histories
   
+  def self.random_select_by(category:, main_ingredients:)
+    # すべてを対象とする
+    scope = Food.all
+  
+    # カテゴリの指定があれば、カテゴリの条件を追加
+    scope = scope.where(category: category) if category.present?
+  
+    # メイン食材の指定があれば、メイン食材の条件を追加
+    scope = scope.where(main_ingredients: main_ingredients) if main_ingredients.present?
+  
+    # ランダムで1個選択し返却する
+    scope.order('RAND()').limit(1).first
+  end
 end

--- a/app/views/foods/index.html.slim
+++ b/app/views/foods/index.html.slim
@@ -1,7 +1,7 @@
 div class='center'
   div class='result'
 
-    = image_tag "sign.gif"
+    = image_tag 'sign.gif'
 
     ruby:
       form_options = {
@@ -17,12 +17,12 @@ div class='center'
     = form_with(form_options) do |f|
       
       p 
-        = f.label "カテゴリー"
+        = f.label 'カテゴリー'
         = f.select :category, food_category_collection, {include_blank: true}, id: 'select'
 
       p
-        = f.label "メイン食材"
-        = f.select :main_ingredients, @main_ingredients, {include_blank: true}, id: "select"
+        = f.label 'メイン食材'
+        = f.select :main_ingredients, @main_ingredients, {include_blank: true}, id: 'select'
 
       p 
         = f.submit '選ぶ!', name: nil, id: 'btn'

--- a/app/views/foods/index.html.slim
+++ b/app/views/foods/index.html.slim
@@ -17,7 +17,12 @@ div class='center'
     = form_with(form_options) do |f|
       
       p 
-        = f.select :category, food_category_collection, {}, id: 'select'
+        = f.label "カテゴリー"
+        = f.select :category, food_category_collection, {include_blank: true}, id: 'select'
+
+      p
+        = f.label "メイン食材"
+        = f.select :main_ingredients, @main_ingredients, {include_blank: true}, id: "select"
 
       p 
         = f.submit '選ぶ!', name: nil, id: 'btn'


### PR DESCRIPTION
## 背景
メイン食材でセレクトボックスがなかったので追加したい。それに伴いセレクトボックスの選択による出力結果が変わるように変更したい。

##対応したこと
- メイン食材のセレクトボックスの追加
- 空項目の追加
- コントローラーのセレクトボックス選択内容による条件分岐の追加